### PR TITLE
Remove a parameter.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+0.0.6  2020-12-22 14:42:17 JST
+       - Remove "update_period" parameter from arguments before "Cache::Memcached::Fast::new()"
+
 0.0.5  2016-07-22 15:36:53 BST
         - Change log entry for the next version
 

--- a/META.json
+++ b/META.json
@@ -70,7 +70,7 @@
          "web" : "https://github.com/zebardy/cache-memcache-elasticache"
       }
    },
-   "version" : "0.0.5",
+   "version" : "0.0.6",
    "x_contributors" : [
       "Aaron Moses <mosesa02@localhost.localdomain>",
       "Aaron Moses <zebardy@gmail.com>"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,7 +33,7 @@ my %WriteMakefileArgs = (
     "Test::Pod" => 0,
     "Test::Routini" => 0
   },
-  "VERSION" => "0.0.5",
+  "VERSION" => "0.0.6",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/lib/Cache/Elasticache/Memcache.pm
+++ b/lib/Cache/Elasticache/Memcache.pm
@@ -54,7 +54,7 @@ use Cache::Memcached::Fast;
 use Try::Tiny;
 use Scalar::Util qw(blessed);
 
-our $VERSION = '0.0.5';
+our $VERSION = '0.0.6';
 
 =pod
 
@@ -98,6 +98,7 @@ sub new {
     $self->{_last_update} = time;
 
     $self->{update_period} = exists $args->{update_period} ? $args->{update_period} : 180;
+    delete @{$args}{'update_period'};
 
     $self->{'_args'} = $args;
     $self->{_memd} = Cache::Memcached::Fast->new($args);


### PR DESCRIPTION
Reason:
Perl error: Unknown parameter: update_period at ~/perl5/perlbrew/perls/perl-5.xx.xx/lib/site_perl/5.xx.xx/Cache/Elasticache/Memcache.pm line 103.

Correction:
I remove "update_period" param from "$args" before "Cache::Memcached::Fast::new()".